### PR TITLE
build: upgrade to eslint 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-yml": "^1.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=7.0.0",
+    "eslint": ">=8.0.0",
     "prettier": ">=2.0.0"
   },
   "devDependencies": {
@@ -54,8 +54,8 @@
     "@commitlint/config-conventional": "^17.0.0",
     "commitizen": "^4.2.3",
     "cz-conventional-changelog": "^3.3.0",
-    "eslint": "^7.32.0",
-    "eslint-config-standard": "^16.0.3",
+    "eslint": "^8.39.0",
+    "eslint-config-standard": "^17.0.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.1",
     "prettier": "^2.2.1",


### PR DESCRIPTION
## Description

ESLint 8 is out and pretty well supported now. I'd like to see if we can upgrade to it.
